### PR TITLE
Update Changelog. Cleanup Makefile. Add coverage.py.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ extend-exclude =
     build,
     dist,
     .venv,
-    venv
+    venv*
 
 extend-ignore = E203, E266, E501, W605
 

--- a/.github/workflows/push-github-action.yml
+++ b/.github/workflows/push-github-action.yml
@@ -33,8 +33,8 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
 
-      - name: Lint check
-        run: poetry run make lint-check
+      - name: Lint
+        run: poetry run make lint
 
       - name: Run tests
         # Run tox using the version of Python in `PATH`

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 
 # tox
 /.tox
+
+# coverage
+.coverage
+htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -1,138 +1,14 @@
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
+# virtualenv
+/venv*
 
-# C extensions
-*.so
+# macOS
+.DS_Store
 
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
+# Python
+*.py[co]
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
+# Poetry
+/dist
 
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-cover/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
+# tox
+/.tox

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-path := .
-
 define Comment
 	- Run `make help` to see all the available options.
 	- Run `make testall` to run all the tests.
@@ -9,23 +7,26 @@ define Comment
 endef
 
 
+path := .
+
+
 .PHONY: help
-help: ## Show this help message.
+help:  ## Show this help message.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 
 .PHONY: test
-test: ## Run the tests against the current version of Python.
+test:  ## Run the tests against the current version of Python.
 	python3 -m unittest
 
 
 .PHONY: testall
-testall: ## Run the tests against all supported versions of Python.
+testall:  ## Run the tests against all supported versions of Python.
 	PYTHONPATH= tox
 
 
 .PHONY: publish
-publish: ## Publish the package to PYPI.
+publish:  ## Publish the package to PyPI.
 	poetry build && \
 	git tag v$$(cat pyproject.toml | grep version | sed 's/[^0-9.]*//g') && \
 	\
@@ -33,12 +34,14 @@ publish: ## Publish the package to PYPI.
 	git push origin --tags
 
 
+# TODO: Rename target to "format". The name "lint" implies a report only.
 .PHONY: lint
-lint: black isort flake mypy	## Apply all the linters.
+lint: black isort flake mypy  ## Reformat code. Run linters.
 
 
+# TODO: Rename target to "lint".
 .PHONY: lint-check
-lint-check:  ## Check whether the codebase satisfies the linter rules.
+lint-check:  ## Check whether the codebase satisfies all lint and reformatter rules.
 	@black --check $(path)
 	@isort --check $(path)
 	@flake8 $(path)
@@ -46,27 +49,27 @@ lint-check:  ## Check whether the codebase satisfies the linter rules.
 
 
 .PHONY: black
-black: ## Apply black.
+black:  ## Reformat code according to Black style.
 	@black --fast $(path)
 
 
 .PHONY: isort
-isort: ## Apply isort.
+isort:  ## Reformat code such that imports are sorted.
 	@isort $(path)
 
 
 .PHONY: flake
-flake: ## Apply flake8.
+flake:  ## Run flake8 linter.
 	@flake8 $(path)
 
 
 .PHONY: mypy
-mypy: ## Apply mypy.
+mypy:  ## Run mypy typechecker.
 	@mypy $(path)
 
 
 .PHONY: coverage
-coverage: ## Apply coverage.
+coverage:  ## Generate code coverage report.
 	coverage run -m unittest
 	coverage html
 	open htmlcov/index.html

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,6 @@ lint: black isort flake mypy	## Apply all the linters.
 
 .PHONY: lint-check
 lint-check:  ## Check whether the codebase satisfies the linter rules.
-	@echo
-	@echo "Checking linter rules..."
-	@echo "========================"
-	@echo
 	@black --check $(path)
 	@isort --check $(path)
 	@flake8 $(path)
@@ -51,46 +47,26 @@ lint-check:  ## Check whether the codebase satisfies the linter rules.
 
 .PHONY: black
 black: ## Apply black.
-	@echo
-	@echo "Applying black..."
-	@echo "================="
-	@echo
 	@black --fast $(path)
-	@echo
 
 
 .PHONY: isort
 isort: ## Apply isort.
-	@echo "Applying isort..."
-	@echo "================="
-	@echo
 	@isort $(path)
 
 
 .PHONY: flake
 flake: ## Apply flake8.
-	@echo
-	@echo "Applying flake8..."
-	@echo "================="
-	@echo
 	@flake8 $(path)
 
 
 .PHONY: mypy
 mypy: ## Apply mypy.
-	@echo
-	@echo "Applying mypy..."
-	@echo "================="
-	@echo
 	@mypy $(path)
 
 
 .PHONY: coverage
 coverage: ## Apply coverage.
-	@echo
-	@echo "Applying coverage..."
-	@echo "================="
-	@echo
 	coverage run -m unittest
 	coverage html
 	open htmlcov/index.html

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 define Comment
 	- Run `make help` to see all the available options.
 	- Run `make testall` to run all the tests.
-	- Run `make lint` to run the linter.
-	- Run `make lint-check` to check linter conformity.
+	- Run `make format` to format code.
+	- Run `make lint` to check linter conformity.
 	- Run `make publish` to publish to PYPI.
 endef
 
@@ -34,18 +34,14 @@ publish:  ## Publish the package to PyPI.
 	git push origin --tags
 
 
-# TODO: Rename target to "format". The name "lint" implies a report only.
+.PHONY: format
+format: black isort flake mypy  ## Reformat code. Run linters.
+
+
 .PHONY: lint
-lint: black isort flake mypy  ## Reformat code. Run linters.
-
-
-# TODO: Rename target to "lint".
-.PHONY: lint-check
-lint-check:  ## Check whether the codebase satisfies all lint and reformatter rules.
+lint: flake mypy  ## Check whether code satisfies all linter and formatter rules.
 	@black --check $(path)
 	@isort --check $(path)
-	@flake8 $(path)
-	@mypy $(path)
 
 
 .PHONY: black

--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,14 @@ mypy: ## Apply mypy.
 	@echo "================="
 	@echo
 	@mypy $(path)
+
+
+.PHONY: coverage
+coverage: ## Apply coverage.
+	@echo
+	@echo "Applying coverage..."
+	@echo "================="
+	@echo
+	coverage run -m unittest
+	coverage html
+	open htmlcov/index.html

--- a/README.md
+++ b/README.md
@@ -122,9 +122,19 @@ Other alternatives for representing data structures in Python include
 
 * See the [Roadmap](https://github.com/davidfstr/trycast/wiki/Roadmap).
 
-### master
+### master (v0.4.0b)
 
-* Setup continuous integration with GitHub Actions.
+* Upgrade development status from Alpha to Beta:
+    * trycast is thoroughly tested.
+    * trycast has high code coverage (92% on Python 3.9).
+    * trycast has been in production use for over a year
+      at [at least one company] without issues
+* Setup continuous integration with GitHub Actions, against Python 3.6 - 3.9.
+* Migrate to the Black code style.
+* Introduce Black and isort code formatters.
+* Introduce flake8 linter.
+
+[at least one company]: https://dafoster.net/projects/techsmart-platform/
 
 ### v0.3.0
 
@@ -165,7 +175,7 @@ Other alternatives for representing data structures in Python include
 * Fix README to appear on PyPI.
 * Add other package metadata, such as the supported Python versions.
 
-### v0.0.1
+### v0.0.1a
 
 * Initial release.
 * Supports typechecking all types found in JSON.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Other alternatives for representing data structures in Python include
 * Migrate to the Black code style.
 * Introduce Black and isort code formatters.
 * Introduce flake8 linter.
+* Introduce coverage.py code coverage reports.
 
 [at least one company]: https://dafoster.net/projects/techsmart-platform/
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,6 +52,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "coverage"
+version = "6.2"
+description = "Code coverage measurement for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "dataclasses"
 version = "0.8"
 description = "A backport of the dataclasses module for Python 3.6"
@@ -331,7 +342,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "ae9f4dc626a4e04490b498fd0081f653e47e8ffa4cbc4eebba85d85c1b6359cd"
+content-hash = "527f0ae93394fd85fa9f679e3aeaa6b77ab81c9d647fe35b67748b24887a1dcf"
 
 [metadata.files]
 appdirs = [
@@ -349,6 +360,55 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+coverage = [
+    {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840"},
+    {file = "coverage-6.2-cp310-cp310-win32.whl", hash = "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c"},
+    {file = "coverage-6.2-cp310-cp310-win_amd64.whl", hash = "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f"},
+    {file = "coverage-6.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76"},
+    {file = "coverage-6.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47"},
+    {file = "coverage-6.2-cp311-cp311-win_amd64.whl", hash = "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64"},
+    {file = "coverage-6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781"},
+    {file = "coverage-6.2-cp36-cp36m-win32.whl", hash = "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a"},
+    {file = "coverage-6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0"},
+    {file = "coverage-6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8"},
+    {file = "coverage-6.2-cp37-cp37m-win32.whl", hash = "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4"},
+    {file = "coverage-6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74"},
+    {file = "coverage-6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57"},
+    {file = "coverage-6.2-cp38-cp38-win32.whl", hash = "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c"},
+    {file = "coverage-6.2-cp38-cp38-win_amd64.whl", hash = "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2"},
+    {file = "coverage-6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3"},
+    {file = "coverage-6.2-cp39-cp39-win32.whl", hash = "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282"},
+    {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
+    {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
+    {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
 dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ classifiers = [  # https://pypi.org/classifiers/
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
+# NOTE: coverage 6.3 requires Python 3.7+
+coverage = "<6.3"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.910"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ strict_optional = true
 profile = "black"
 atomic = true
 line_length = 88
+skip_glob = ["venv*"]
 
 # === Black ===
 [tool.black]


### PR DESCRIPTION
In particular:
* Changelog: Mention changes by rednafi in June 2021
* Makefile: Simplify. Rename targets to clarify difference between destructive formatters and regular linters.
* Add coverage.py so that I can generate code coverage %ages for the changelog.