### PR TITLE
Support PEP 655: Required[] and NotRequired[] from typing_extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Other alternatives for representing data structures in Python include
 ### main
 
 * Rename primary development branch from `master` to `main`
+* Recognize `Required[]` and `NotRequired[]` from [PEP 655],
+  as imported from `typing_extensions`.
+
+[PEP 655]: https://www.python.org/dev/peps/pep-0655/
 
 ### v0.4.0b
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -313,7 +313,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "typing-extensions"
-version = "4.0.1"
+version = "4.1.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "dev"
 optional = false
@@ -572,8 +572,8 @@ typed-ast = [
     {file = "typed_ast-1.5.2.tar.gz", hash = "sha256:525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
-    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 virtualenv = [
     {file = "virtualenv-20.13.0-py2.py3-none-any.whl", hash = "sha256:339f16c4a86b44240ba7223d0f93a7887c3ca04b5f9c8129da7958447d079b09"},

--- a/tests.py
+++ b/tests.py
@@ -747,6 +747,33 @@ class TestTryCast(TestCase):
             ),
         )
 
+    def test_typeddict_required_notrequired(self) -> None:
+        import typing_extensions
+
+        class TotalMovie(typing_extensions.TypedDict):
+            title: str
+            year: typing_extensions.NotRequired[int]
+
+        class NontotalMovie(typing_extensions.TypedDict, total=False):
+            title: typing_extensions.Required[str]
+            year: int
+
+        # TotalMovie
+        self.assertTryCastSuccess(TotalMovie, {"title": "Blade Runner", "year": 1982})
+        self.assertTryCastSuccess(TotalMovie, {"title": "Blade Runner"})
+        self.assertTryCastFailure(
+            TotalMovie, {"title": "Blade Runner", "year": "Blade Runner"}
+        )
+        self.assertTryCastFailure(TotalMovie, {"year": 1982})
+
+        # NontotalMovie
+        self.assertTryCastSuccess(
+            NontotalMovie, {"title": "Blade Runner", "year": 1982}
+        )
+        self.assertTryCastSuccess(NontotalMovie, {"title": "Blade Runner"})
+        self.assertTryCastFailure(NontotalMovie, {"title": 1982, "year": 1982})
+        self.assertTryCastFailure(NontotalMovie, {"year": 1982})
+
     def test_typeddict_using_mapping_value(self) -> None:
         class NamedObject(TypedDict):
             name: str

--- a/tests.py
+++ b/tests.py
@@ -751,7 +751,7 @@ class TestTryCast(TestCase):
         import typing_extensions
 
         if not hasattr(typing_extensions, "get_type_hints"):
-            self.skipTest("Checking for Required and NotRequired requires python 3.7+")
+            self.skipTest("Checking for Required and NotRequired requires Python 3.7+")
 
         class TotalMovie(typing_extensions.TypedDict):
             title: str

--- a/tests.py
+++ b/tests.py
@@ -750,6 +750,9 @@ class TestTryCast(TestCase):
     def test_typeddict_required_notrequired(self) -> None:
         import typing_extensions
 
+        if not hasattr(typing_extensions, "get_type_hints"):
+            self.skipTest("Checking for Required and NotRequired requires python 3.7+")
+
         class TotalMovie(typing_extensions.TypedDict):
             title: str
             year: typing_extensions.NotRequired[int]

--- a/trycast.py
+++ b/trycast.py
@@ -23,7 +23,8 @@ try:
     # Python 3.7+
     from typing_extensions import get_type_hints  # type: ignore[attr-defined]
 except ImportError:
-    from typing import get_type_hints  # type: ignore[misc]  # Python 3.6
+    # Python 3.6
+    from typing import get_type_hints  # type: ignore[misc]  # incompatible import
 
 # Literal
 if sys.version_info >= (3, 8):

--- a/trycast.py
+++ b/trycast.py
@@ -20,9 +20,10 @@ from typing import (
 )
 
 try:
-    from typing_extensions import get_type_hints
+    # Requires Python 3.7+
+    from typing_extensions import get_type_hints  # type: ignore [attr-defined]
 except ImportError:
-    from typing import get_type_hints
+    from typing import get_type_hints  # type: ignore [misc]  # incompatible import
 
 # Literal
 if sys.version_info >= (3, 8):

--- a/trycast.py
+++ b/trycast.py
@@ -20,10 +20,10 @@ from typing import (
 )
 
 try:
-    # Requires Python 3.7+
-    from typing_extensions import get_type_hints  # type: ignore [attr-defined]
+    # Python 3.7+
+    from typing_extensions import get_type_hints  # type: ignore[attr-defined]
 except ImportError:
-    from typing import get_type_hints  # type: ignore [misc]  # incompatible import
+    from typing import get_type_hints  # type: ignore[misc]  # Python 3.6
 
 # Literal
 if sys.version_info >= (3, 8):

--- a/trycast.py
+++ b/trycast.py
@@ -16,9 +16,13 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_type_hints,
     overload,
 )
+
+try:
+    from typing_extensions import get_type_hints
+except ImportError:
+    from typing import get_type_hints
 
 # Literal
 if sys.version_info >= (3, 8):


### PR DESCRIPTION
Fixes #11 (partially).

- import `get_type_hints` from typing_extensions if possible (necessary to strip Required[] and NotRequired[])
- use latest version of typing_extensions for tests (provides (Not)Required-aware get_type_hints)
- write tests