### PR TITLE
Support types.UnionType for complex types

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -965,6 +965,22 @@ class TestTryCast(TestCase):
         # non-Optional[str]
         self.assertTryCastFailure(Optional[str], [])
 
+    def test_uniontype(self) -> None:
+        if sys.version_info < (3, 10):
+            self.skipTest("UnionType requires Python 3.10 or later")
+
+        # int | str, equivalent to Union[int, str]
+        self.assertTryCastSuccess(int | str, 1)  # type: ignore[operator]
+        self.assertTryCastSuccess(int | str, "foo")  # type: ignore[operator]
+
+        # non-(int | str)
+        self.assertTryCastFailure(int | str, [])  # type: ignore[operator]
+
+        # UnionType with TypedDict
+        self.assertTryCastSuccess(_Movie | None, _Movie(name="Blade Runner", year=1982))  # type: ignore[operator]
+        self.assertTryCastSuccess(_Movie | None, None)  # type: ignore[operator]
+        self.assertTryCastFailure(_Movie | None, {})  # type: ignore[operator]
+
     # === Literals ===
 
     def test_literal(self) -> None:

--- a/trycast.py
+++ b/trycast.py
@@ -30,6 +30,14 @@ from typing import _eval_type as eval_type  # type: ignore[attr-defined]
 from typing import _type_check as type_check  # type: ignore[attr-defined]
 from typing import cast, overload
 
+try:
+    from types import UnionType  # type: ignore[attr-defined]
+except ImportError:
+
+    class UnionType(type):  # type: ignore[no-redef]
+        ...
+
+
 # get_type_hints
 try:
     # Python 3.7+
@@ -404,7 +412,7 @@ def _trycast_inner(tp, value, failure, options):
     ):  # MutableMapping, MutableMapping[K, V]
         return _trycast_dictlike(tp, value, failure, CMutableMapping, options)
 
-    if type_origin is Union:  # Union[T1, T2, ...]
+    if type_origin is Union or type_origin is UnionType:  # Union[T1, T2, ...]
         for T in get_args(tp):
             if _trycast_inner(T, value, _FAILURE, options) is not _FAILURE:  # type: ignore[wrong-arg-types]  # pytype
                 if isinstance(tp, type):


### PR DESCRIPTION
If passing `types.Uniontype` (e.g. `int | str`) to trycast, it gets passed to `isinstance()`, which works well with simple types, but can't handle more complex types such as `TypedDict`s, resulting in a `TypeError`.

This PR solves this by handling `types.UnionType` the same way as `typing.Union` if union type expressions are implemented (on Python >=3.10).